### PR TITLE
feat: add server_type for universal translation server adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,28 @@ add this to one of the configuration files (eg `~./config/mycroft/mycroft.conf`)
     }
 }
 ```
+
+### Universal adapter (`server_type`)
+
+By default the plugin talks to a native `ovos-translate-server`
+(`server_type: "ovos"`). Set `server_type` to target any other compatible
+translation API — the plugin becomes a universal adapter:
+
+```javascript
+"language": {
+    "translation_module": "ovos-translate-plugin-server",
+    "ovos-translate-plugin-server": {
+        "server_type": "deepl",
+        "host": "https://api-free.deepl.com",
+        "api_key": "..."
+    }
+}
+```
+
+| `server_type` | Endpoint used | `host` example | Notes |
+|---|---|---|---|
+| `ovos` (default) | `/translate/{src}/{tgt}/{text}` | `http://host:9686` | native ovos-translate-server |
+| `libretranslate` | `POST /translate` | `http://localhost:5000` | any self-hosted/hosted LibreTranslate (`api_key` optional) |
+| `deepl` | `POST /v2/translate` | `https://api-free.deepl.com` | `api_key` → `Authorization: DeepL-Auth-Key` |
+
+For vendor server types an explicit `host` is required.

--- a/ovos_translate_server_plugin/__init__.py
+++ b/ovos_translate_server_plugin/__init__.py
@@ -138,12 +138,29 @@ class OVOSTranslateServer(LanguageTranslator):
         """Request timeout in seconds (config key ``timeout``, default 20)."""
         return self.config.get("timeout", _DEFAULT_TIMEOUT)
 
+    @property
+    def server_type(self) -> str:
+        """Which server API to speak to.
+
+        ``ovos`` (default) talks to a native ovos-translate-server. Any other
+        value turns this plugin into an adapter for a third-party translation
+        API so it can target any compatible server:
+        - ``libretranslate``: any self-hosted/hosted LibreTranslate instance.
+        - ``deepl``: the official DeepL ``/v2/translate`` API.
+        """
+        return self.config.get("server_type", "ovos")
+
+    @property
+    def api_key(self) -> Optional[str]:
+        """API key for vendor server types. Optional for LibreTranslate."""
+        return self.config.get("api_key")
+
     def translate(self,
                   text: Union[str, List[str]],
                   target: str = "",
                   source: str = "") -> Union[str, List[str]]:
         """
-        NLLB200 translate text(s) into the target language.
+        Translate text(s) into the target language.
 
         Args:
             text (Union[str, List[str]]): Sentence(s) to translate.
@@ -154,6 +171,9 @@ class OVOSTranslateServer(LanguageTranslator):
             Union[str, List[str]]: Translation(s).
         """
         target = target or self.internal_language
+
+        if self.server_type != "ovos":
+            return self._translate_vendor(text, target, source)
 
         text = text.replace("/", "-")  # HACK - if text has a / the url is invalid
         for url in self.get_servers():
@@ -186,6 +206,64 @@ class OVOSTranslateServer(LanguageTranslator):
             except Exception:
                 LOG.exception(f"Error contacting {url}")
         raise RuntimeError("All OVOS Translate servers are down!")
+
+    def _translate_vendor(self, text: str, target: str, source: str) -> str:
+        """Translate via a third-party translation API (non-ovos server types)."""
+        if not self.host:
+            raise RuntimeError(
+                f"server_type={self.server_type!r} requires an explicit 'host'")
+        for url in self.get_servers():
+            try:
+                if self.server_type == "libretranslate":
+                    out = self._translate_libretranslate(url, text, target, source)
+                elif self.server_type == "deepl":
+                    out = self._translate_deepl(url, text, target, source)
+                else:
+                    raise RuntimeError(f"unknown server_type {self.server_type!r}")
+                if out is not None:
+                    return out
+            except requests.exceptions.Timeout:
+                LOG.warning(f"Timeout contacting {url} — trying next server")
+            except Exception:
+                LOG.exception(f"Error contacting {url}")
+        raise RuntimeError(f"All {self.server_type} translate servers are down!")
+
+    def _translate_libretranslate(self, url: str, text: str, target: str,
+                                  source: str) -> Optional[str]:
+        """LibreTranslate POST /translate."""
+        endpoint = f"{url.rstrip('/')}/translate"
+        body = {"q": text, "source": source or "auto", "target": target, "format": "text"}
+        if self.api_key:
+            body["api_key"] = self.api_key
+        r = requests.post(endpoint, data=body, timeout=self.timeout)
+        if r.status_code >= 500:
+            LOG.warning(f"Server error {r.status_code} from {endpoint} — trying next server")
+            return None
+        if r.ok:
+            return r.json()["translatedText"]
+        LOG.error(f"{r.status_code} response from {endpoint}: {r.text}")
+        return None
+
+    def _translate_deepl(self, url: str, text: str, target: str,
+                         source: str) -> Optional[str]:
+        """DeepL POST /v2/translate (DeepL uses upper-case language codes)."""
+        endpoint = url.rstrip("/")
+        if not endpoint.endswith("/v2/translate"):
+            endpoint += "/v2/translate"
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"DeepL-Auth-Key {self.api_key}"
+        data = {"text": text, "target_lang": target.upper()}
+        if source:
+            data["source_lang"] = source.upper()
+        r = requests.post(endpoint, data=data, headers=headers, timeout=self.timeout)
+        if r.status_code >= 500:
+            LOG.warning(f"Server error {r.status_code} from {endpoint} — trying next server")
+            return None
+        if r.ok:
+            return r.json()["translations"][0]["text"]
+        LOG.error(f"{r.status_code} response from {endpoint}: {r.text}")
+        return None
 
     def get_servers(self) -> List[str]:
         """

--- a/test/test_e2e_server_type.py
+++ b/test/test_e2e_server_type.py
@@ -1,0 +1,58 @@
+# pylint: disable=missing-docstring,redefined-outer-name,protected-access
+"""End-to-end tests for the server_type adapter over a real socket.
+
+The plugin *is* the client, so these run the real plugin (real ``requests``
+HTTP) against a real local server speaking the vendor wire format. No mocking,
+no external network.
+"""
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from ovos_translate_server_plugin import OVOSTranslateServer
+
+
+class _VendorHandler(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def _json(self, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        path = self.path.split("?")[0]
+        if path.endswith("/translate") and not path.endswith("/v2/translate"):  # LibreTranslate
+            self._json({"translatedText": "hola mundo"})
+        elif path.endswith("/v2/translate"):  # DeepL
+            self._json({"translations": [{"text": "Hallo Welt"}]})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+@pytest.fixture(scope="module")
+def vendor_server():
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _VendorHandler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}"
+    srv.shutdown()
+
+
+def test_libretranslate_end_to_end(vendor_server):
+    tx = OVOSTranslateServer(config={"server_type": "libretranslate", "host": vendor_server})
+    assert tx.translate("hello world", target="es", source="en") == "hola mundo"
+
+
+def test_deepl_end_to_end(vendor_server):
+    tx = OVOSTranslateServer(config={"server_type": "deepl", "host": vendor_server,
+                                     "api_key": "dl-test"})
+    assert tx.translate("hello world", target="de", source="en") == "Hallo Welt"

--- a/test/test_server_type.py
+++ b/test/test_server_type.py
@@ -1,0 +1,74 @@
+# pylint: disable=missing-docstring,redefined-outer-name,protected-access
+"""Unit tests for the server_type universal adapter (mocked HTTP)."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from ovos_translate_server_plugin import OVOSTranslateServer
+
+
+def _resp(ok=True, status=200, json_data=None) -> MagicMock:
+    r = MagicMock()
+    r.ok = ok
+    r.status_code = status
+    r.text = ""
+    if json_data is not None:
+        r.json.return_value = json_data
+    return r
+
+
+def test_default_server_type_is_ovos():
+    assert OVOSTranslateServer().server_type == "ovos"
+
+
+def test_libretranslate_request_shape():
+    tx = OVOSTranslateServer(config={"server_type": "libretranslate",
+                                     "host": "http://localhost:5000",
+                                     "api_key": "lt-test"})
+    with patch("ovos_translate_server_plugin.requests.post",
+               return_value=_resp(json_data={"translatedText": "hola mundo"})) as post:
+        out = tx.translate("hello world", target="es", source="en")
+    assert out == "hola mundo"
+    args, kwargs = post.call_args
+    assert args[0] == "http://localhost:5000/translate"
+    assert kwargs["data"]["q"] == "hello world"
+    assert kwargs["data"]["source"] == "en"
+    assert kwargs["data"]["target"] == "es"
+    assert kwargs["data"]["api_key"] == "lt-test"
+
+
+def test_libretranslate_source_defaults_to_auto():
+    tx = OVOSTranslateServer(config={"server_type": "libretranslate",
+                                     "host": "http://localhost:5000"})
+    with patch("ovos_translate_server_plugin.requests.post",
+               return_value=_resp(json_data={"translatedText": "hola"})) as post:
+        tx.translate("hello", target="es")
+    assert post.call_args.kwargs["data"]["source"] == "auto"
+
+
+def test_deepl_request_shape():
+    tx = OVOSTranslateServer(config={"server_type": "deepl",
+                                     "host": "https://api-free.deepl.com",
+                                     "api_key": "dl-test"})
+    with patch("ovos_translate_server_plugin.requests.post",
+               return_value=_resp(json_data={"translations": [{"text": "Hallo Welt"}]})) as post:
+        out = tx.translate("hello world", target="de", source="en")
+    assert out == "Hallo Welt"
+    args, kwargs = post.call_args
+    assert args[0] == "https://api-free.deepl.com/v2/translate"
+    assert kwargs["headers"]["Authorization"] == "DeepL-Auth-Key dl-test"
+    # DeepL expects upper-case language codes
+    assert kwargs["data"]["target_lang"] == "DE"
+    assert kwargs["data"]["source_lang"] == "EN"
+
+
+def test_vendor_type_requires_host():
+    tx = OVOSTranslateServer(config={"server_type": "libretranslate"})
+    with pytest.raises(RuntimeError):
+        tx.translate("hello", target="es")
+
+
+def test_unknown_server_type_raises():
+    tx = OVOSTranslateServer(config={"server_type": "bogus", "host": "http://localhost:5000"})
+    with pytest.raises(RuntimeError):
+        tx.translate("hello", target="es")


### PR DESCRIPTION
## Summary
Turns the companion plugin into a universal translation server adapter. A new `server_type` config (default `ovos`, behavior unchanged) lets a device offload translation to **any** compatible API:

| `server_type` | Endpoint | Covers |
|---|---|---|
| `ovos` (default) | `/translate/{src}/{tgt}/{text}` | native ovos-translate-server |
| `libretranslate` | `POST /translate` | any self-hosted/hosted LibreTranslate |
| `deepl` | `POST /v2/translate` | official DeepL API |

Vendor types require an explicit `host`.

## Tests
- `test_server_type.py` — mocked unit tests (endpoint, headers, body shape, upper-case DeepL codes, error paths).
- `test_e2e_server_type.py` — real-socket e2e: real plugin over HTTP against a vendor-shaped local server.
- Full suite: **28 passed** (existing ovos path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)