### PR TITLE
docs: timeout docstring says default 20 but code default is 5

### DIFF
--- a/ovos_translate_server_plugin/__init__.py
+++ b/ovos_translate_server_plugin/__init__.py
@@ -29,7 +29,7 @@ class OVOSLangDetectServer(LanguageDetector):
 
     @property
     def timeout(self) -> int:
-        """Request timeout in seconds (config key ``timeout``, default 20)."""
+        """Request timeout in seconds (config key ``timeout``, default 5)."""
         return self.config.get("timeout", _DEFAULT_TIMEOUT)
 
     def detect(self, text: str) -> str:
@@ -135,7 +135,7 @@ class OVOSTranslateServer(LanguageTranslator):
 
     @property
     def timeout(self) -> int:
-        """Request timeout in seconds (config key ``timeout``, default 20)."""
+        """Request timeout in seconds (config key ``timeout``, default 5)."""
         return self.config.get("timeout", _DEFAULT_TIMEOUT)
 
     def translate(self,


### PR DESCRIPTION
Both `timeout` properties' docstrings say 'default 20', but `_DEFAULT_TIMEOUT = 5`. Corrected the docstrings to match the actual 5s behavior. Found auditing for the Technical Manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)