### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
-Language Plugin for [ovos translate server](https://github.com/OpenVoiceOS/ovos-translate-server)
+# ovos-translate-server-plugin
+
+An OVOS plugin for language detection and translation. It sends requests to [ovos-translate-server](https://github.com/OpenVoiceOS/ovos-translate-server) and returns the result. The server does the work. This plugin is the client.
+
+It registers two OVOS plugin manager entry points:
+
+- `ovos-lang-detector-plugin-server`: detects the language of a text.
+- `ovos-translate-plugin-server`: translates text into a target language.
+
+Other OVOS components use these plugins to translate utterances and texts on demand, for example [solvers](https://openvoiceos.github.io/ovos-technical-manual/solvers/) and [ovos-bidirectional-translation-plugin](https://github.com/OpenVoiceOS/ovos-bidirectional-translation-plugin).
+
+## Install
+
+```bash
+pip install ovos-translate-server-plugin
+```
 
 ## Usage
 
-### OVOS
-
-The plugin is used in a wider context to translate utterances/texts on demand (e.g. from [solvers](https://openvoiceos.github.io/ovos-technical-manual/solvers/) and [ovos-bidirectional-translation-plugin](https://github.com/OpenVoiceOS/ovos-bidirectional-translation-plugin))
-
-add this to one of the configuration files (eg `~./config/mycroft/mycroft.conf`)
+Add this to your OVOS configuration file (for example `~/.config/mycroft/mycroft.conf`):
 
 ```javascript
 "language": {
@@ -20,3 +31,22 @@ add this to one of the configuration files (eg `~./config/mycroft/mycroft.conf`)
     }
 }
 ```
+
+The `host` key sets the server address. It takes a single URL or a list of URLs. Give a list to spread requests across several servers and to add a fallback if one server goes down.
+
+If you omit `host`, the plugin uses its own list of public servers.
+
+Other config keys:
+
+- `timeout`: request timeout in seconds. Default: 5.
+- `skip_detection` (translation plugin only): skip automatic source-language detection when no source language is given. Default: false.
+
+## Related projects
+
+- [ovos-translate-server](https://github.com/OpenVoiceOS/ovos-translate-server): the server this plugin talks to.
+- [ovos-bidirectional-translation-plugin](https://github.com/OpenVoiceOS/ovos-bidirectional-translation-plugin): a consumer of this plugin.
+- [ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): the plugin framework this project implements.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README for clarity: states what the plugin does, lists its two entry points, documents all config keys (host, timeout, skip_detection), and adds a related-projects section linking the server, a consumer plugin, and ovos-plugin-manager.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with installation and configuration guidance.
  * Documented available entry points, server selection, fallback behavior, timeout and detection options.
  * Added references to related projects and Apache-2.0 licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->